### PR TITLE
Add branching strategy and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+Instructions for Claude Code when working on the sayou repository.
+
+## Branching Strategy
+
+**Read [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) before making any commits.**
+
+Key rules:
+- **NEVER push directly to `main`**. All changes go through feature branches and PRs.
+- Branch naming: `feat/<name>`, `fix/<name>`, `chore/<name>`, `refactor/<name>`, `test/<name>`
+- PRs are squash-merged to keep `main` history clean.
+- Tag releases on `main` with annotated tags: `git tag -a vX.Y.Z -m "description"`
+
+### Workflow
+
+```bash
+# Start work
+git checkout main && git pull
+git checkout -b feat/my-feature
+
+# After changes
+git push -u origin feat/my-feature
+gh pr create --title "Add my feature" --body "Description"
+
+# NEVER do this:
+git push origin main
+```
+
+## Development
+
+```bash
+# Install with dev dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest
+
+# Lint
+ruff check .
+```
+
+## Architecture
+
+- `sayou/server/__init__.py` — MCP tool registration (11 tools). This is the main agent interface.
+- `sayou/config.py` — Settings with env prefix `SAYOU_`. Config priority: env vars > `~/.sayou/config.yaml` > defaults.
+- `sayou/catalog/database.py` — Database initialization and engine creation.
+- `sayou/workspace.py` — Public Python API (`Workspace` class).
+- `sayou/core/workspace.py` — Core workspace implementation.
+- `sayou/cli/` — CLI commands (`init`, `status`).
+- `sayou/__main__.py` — CLI entry point and MCP server startup.
+
+## Testing
+
+- All tests in `tests/`. Run with `pytest`.
+- `test_smoke.py` verifies MCP tool registration.
+- Tests requiring `SAYOU_EMBEDDING_PROVIDER` are skipped when not configured.
+- All PRs must pass tests before merge.
+
+## Release Process
+
+1. Bump version in `pyproject.toml`
+2. Merge PR to `main`
+3. Tag: `git tag -a vX.Y.Z -m "description"`
+4. Push tag: `git push origin vX.Y.Z`
+5. CI publishes to PyPI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 Thank you for your interest in contributing to sayou.
 
+## Branching & Pull Requests
+
+Read [docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md) for the full branching strategy.
+
+**Quick version:** Branch from `main`, open a PR, get it reviewed, squash-merge. Never push directly to `main`.
+
+```bash
+git checkout -b feat/my-feature
+# make changes, commit, push
+gh pr create --title "Add my feature"
+```
+
 ## Reporting Issues
 
 Open an issue on GitHub with:

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -1,0 +1,100 @@
+# Branching Strategy
+
+sayou follows a trunk-based development model with short-lived feature branches and tagged releases.
+
+## Branches
+
+| Branch | Purpose | Protected |
+|--------|---------|-----------|
+| `main` | Stable release branch. Every commit on `main` is deployable. | Yes |
+| `feat/<name>` | Feature work. Branched from `main`, merged via PR. | No |
+| `fix/<name>` | Bug fixes. Branched from `main`, merged via PR. | No |
+| `chore/<name>` | Maintenance (deps, CI, docs). Branched from `main`, merged via PR. | No |
+
+## Workflow
+
+### 1. Start from main
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/my-feature
+```
+
+### 2. Work on your branch
+
+- Make small, focused commits
+- Write tests for new functionality
+- Keep the branch short-lived (ideally < 1 week)
+
+### 3. Open a pull request
+
+```bash
+git push -u origin feat/my-feature
+gh pr create --title "Add my feature" --body "Description of changes"
+```
+
+PR requirements:
+- Descriptive title (under 70 characters)
+- Summary of what changed and why
+- All tests must pass
+- At least one approval before merge
+
+### 4. Merge and clean up
+
+PRs are merged via **squash merge** to keep `main` history clean. Delete the branch after merge.
+
+## Releases
+
+Releases are tagged on `main` using semantic versioning:
+
+```bash
+git tag -a v0.2.0 -m "v0.2.0: Zero-config defaults, tool consolidation, CLI"
+git push origin v0.2.0
+```
+
+### Version Numbering
+
+| Version | Meaning |
+|---------|---------|
+| `v0.x.y` | Pre-1.0 development. Minor bumps may include breaking changes. |
+| `v1.0.0` | First stable release. Semver rules apply from here. |
+| `vX.Y.Z` | `X` = breaking, `Y` = features, `Z` = fixes |
+
+### Release Checklist
+
+1. All PRs for the release are merged to `main`
+2. `pytest` passes with zero failures
+3. Version in `pyproject.toml` matches the tag
+4. Create annotated tag: `git tag -a vX.Y.Z -m "description"`
+5. Push tag: `git push origin vX.Y.Z`
+6. GitHub Actions publishes to PyPI automatically
+
+## Branch Protection Rules (main)
+
+- No direct pushes — all changes via PR
+- Require passing CI checks
+- Require at least 1 approval
+- Squash merge only
+
+## Hotfixes
+
+For urgent production fixes:
+
+```bash
+git checkout main
+git checkout -b fix/critical-bug
+# fix, commit, push, PR
+```
+
+Hotfixes follow the same PR flow but are prioritized for review.
+
+## Naming Conventions
+
+| Prefix | Use |
+|--------|-----|
+| `feat/` | New features or capabilities |
+| `fix/` | Bug fixes |
+| `chore/` | Dependencies, CI, docs, tooling |
+| `refactor/` | Code restructuring without behavior change |
+| `test/` | Test additions or improvements |


### PR DESCRIPTION
## Summary
- Add `docs/BRANCHING_STRATEGY.md` — trunk-based development with feature branches, PRs, and tagged releases
- Add `CLAUDE.md` — instructions for Claude Code (never push to main, branch naming, architecture overview)
- Update `CONTRIBUTING.md` to reference the branching strategy
- Branch protection enabled on `main` (requires 1 approval, no direct pushes)

## Test plan
- [ ] Verify branch protection blocks direct pushes to main
- [ ] Verify docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)