### PR TITLE
Add --claude, --cursor, --windsurf flags to sayou init

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,35 +16,15 @@ Databases were designed for transactions — they reduce nuance to fit a schema.
 
 ## Quick Start
 
-### 1. Install
 ```bash
-pip install sayou
+pip install sayou && sayou init --claude
 ```
 
-### 2. Initialize
-```bash
-sayou init
-```
+That's it. Restart Claude Code and you're connected.
 
-### 3. Connect to Claude Code
+`--claude` auto-configures `~/.claude/mcp.json`. You can also use `--cursor` or `--windsurf`, or run `sayou init` without flags to get the config snippet to paste manually.
 
-Add to `~/.claude/mcp.json`:
-```json
-{
-  "mcpServers": {
-    "sayou": { "command": "sayou" }
-  }
-}
-```
-
-### 4. Verify
-
-Restart Claude Code (so it picks up the new MCP config), then run:
-```bash
-sayou status
-```
-
-You should see your workspace path, database location, and `11 tools registered`. If you see errors, jump to [Troubleshooting](#troubleshooting).
+To verify, run `sayou status` — you should see your workspace path, database location, and `11 tools registered`. If you see errors, jump to [Troubleshooting](#troubleshooting).
 
 ## Try It
 
@@ -113,29 +93,23 @@ The key insight: Claude Code remembered the research **across sessions** because
 
 ### Cursor
 
-Add to `.cursor/mcp.json` in your project root:
-```json
-{
-  "mcpServers": {
-    "sayou": { "command": "sayou" }
-  }
-}
+```bash
+sayou init --cursor
 ```
+
+This adds sayou to `.cursor/mcp.json` in your current working directory.
 
 ### Windsurf
 
-Add to `~/.codeium/windsurf/mcp_config.json`:
-```json
-{
-  "mcpServers": {
-    "sayou": { "command": "sayou" }
-  }
-}
+```bash
+sayou init --windsurf
 ```
+
+This adds sayou to `~/.codeium/windsurf/mcp_config.json`.
 
 ### Any MCP-compatible client
 
-sayou is a standard MCP server. The config is always the same — just `"command": "sayou"`. Check your editor's docs for where it reads MCP server configuration.
+sayou is a standard MCP server. Run `sayou init` (no flag) to get the config snippet, then paste it into your editor's MCP config. The entry is always the same — just `"command": "sayou"`.
 
 ## MCP Tools
 

--- a/sayou/__main__.py
+++ b/sayou/__main__.py
@@ -138,7 +138,10 @@ def main():
     _add_common_args(kl)
 
     # ── init ─────────────────────────────────────────────────────
-    subparsers.add_parser("init", help="Initialize local sayou setup")
+    init_parser = subparsers.add_parser("init", help="Initialize local sayou setup")
+    init_parser.add_argument("--claude", action="store_true", help="Auto-configure Claude Code (~/.claude/mcp.json)")
+    init_parser.add_argument("--cursor", action="store_true", help="Auto-configure Cursor (.cursor/mcp.json)")
+    init_parser.add_argument("--windsurf", action="store_true", help="Auto-configure Windsurf (~/.codeium/windsurf/mcp_config.json)")
 
     # ── status ───────────────────────────────────────────────────
     subparsers.add_parser("status", help="Show sayou diagnostic status")
@@ -173,7 +176,12 @@ def main():
 
     if args.command == "init":
         from sayou.cli.init import run_init
-        asyncio.run(run_init())
+        editor = None
+        for name in ("claude", "cursor", "windsurf"):
+            if getattr(args, name, False):
+                editor = name
+                break
+        asyncio.run(run_init(editor=editor))
         return
 
     if args.command == "status":

--- a/sayou/cli/init.py
+++ b/sayou/cli/init.py
@@ -18,16 +18,47 @@ DEFAULT_CONFIG = {
     "workspace": "default",
 }
 
-MCP_CONFIG = {
-    "mcpServers": {
-        "sayou": {
-            "command": "sayou",
-        }
-    }
+MCP_ENTRY = {
+    "command": "sayou",
+}
+
+EDITOR_CONFIGS: dict[str, Path] = {
+    "claude": Path.home() / ".claude" / "mcp.json",
+    "cursor": Path.cwd() / ".cursor" / "mcp.json",
+    "windsurf": Path.home() / ".codeium" / "windsurf" / "mcp_config.json",
 }
 
 
-async def run_init() -> None:
+def _configure_editor(editor: str) -> None:
+    """Add sayou to an editor's MCP config file."""
+    path = EDITOR_CONFIGS[editor]
+
+    # Read existing config or start fresh
+    if path.exists():
+        with open(path) as f:
+            try:
+                config = json.load(f)
+            except json.JSONDecodeError:
+                print(f"  Warning: {path} contains invalid JSON, overwriting")
+                config = {}
+    else:
+        config = {}
+
+    servers = config.setdefault("mcpServers", {})
+
+    if "sayou" in servers:
+        print(f"  Already configured in {path}")
+        return
+
+    servers["sayou"] = MCP_ENTRY
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+    print(f"  Configured {path}")
+
+
+async def run_init(editor: str | None = None) -> None:
     """Initialize sayou local setup."""
     # 1. Create directories
     SAYOU_DIR.mkdir(parents=True, exist_ok=True)
@@ -49,7 +80,17 @@ async def run_init() -> None:
     await init_db(db_url)
     print(f"  Database ready: {DB_FILE}")
 
-    # 4. Print MCP config
-    print(f"\nReady! Add to your MCP client config:\n")
-    print(json.dumps(MCP_CONFIG, indent=2))
-    print()
+    # 4. Configure editor or print manual instructions
+    if editor:
+        _configure_editor(editor)
+        print(f"\n  Restart {editor.title()} to connect.")
+    else:
+        print(f"\nReady! Add to your MCP client config:\n")
+        mcp_config = {"mcpServers": {"sayou": MCP_ENTRY}}
+        print(json.dumps(mcp_config, indent=2))
+        print()
+        print("Or re-run with an editor flag to auto-configure:")
+        print("  sayou init --claude")
+        print("  sayou init --cursor")
+        print("  sayou init --windsurf")
+        print()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -302,6 +302,43 @@ async def test_cli_audit(ws_kwargs, capsys):
 
 
 @pytest.mark.asyncio
+async def test_init_configure_editor(tmp_path):
+    """sayou init --claude writes mcp.json correctly."""
+    from sayou.cli.init import _configure_editor, EDITOR_CONFIGS
+    from unittest.mock import patch
+
+    mcp_path = tmp_path / "mcp.json"
+
+    with patch.dict(EDITOR_CONFIGS, {"claude": mcp_path}):
+        # First call: creates file
+        _configure_editor("claude")
+        data = json.loads(mcp_path.read_text())
+        assert data == {"mcpServers": {"sayou": {"command": "sayou"}}}
+
+        # Second call: idempotent (doesn't duplicate)
+        _configure_editor("claude")
+        data = json.loads(mcp_path.read_text())
+        assert data == {"mcpServers": {"sayou": {"command": "sayou"}}}
+
+
+@pytest.mark.asyncio
+async def test_init_configure_editor_preserves_existing(tmp_path):
+    """sayou init --claude preserves existing MCP servers."""
+    from sayou.cli.init import _configure_editor, EDITOR_CONFIGS
+    from unittest.mock import patch
+
+    mcp_path = tmp_path / "mcp.json"
+    existing = {"mcpServers": {"other-server": {"command": "other"}}}
+    mcp_path.write_text(json.dumps(existing))
+
+    with patch.dict(EDITOR_CONFIGS, {"claude": mcp_path}):
+        _configure_editor("claude")
+        data = json.loads(mcp_path.read_text())
+        assert "other-server" in data["mcpServers"]
+        assert "sayou" in data["mcpServers"]
+
+
+@pytest.mark.asyncio
 async def test_cli_argparse_structure():
     """Verify argparse subparsers are structured correctly."""
     from sayou.__main__ import main


### PR DESCRIPTION
## Summary
- `sayou init --claude` auto-configures `~/.claude/mcp.json` (also `--cursor`, `--windsurf`)
- Merges into existing config without overwriting other MCP servers
- Idempotent — safe to run multiple times
- README quickstart condensed to a one-liner: `pip install sayou && sayou init --claude`

## Test plan
- [x] New tests: `test_init_configure_editor` and `test_init_configure_editor_preserves_existing`
- [x] All 11 CLI tests pass
- [ ] Manual: `sayou init --claude` creates/updates `~/.claude/mcp.json`
- [ ] Manual: Restart Claude Code, verify sayou tools appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)