### PR TITLE
Add Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "pixell-global",
+  "owner": { "name": "Pixell" },
+  "metadata": {
+    "description": "Sayou — persistent knowledge workspace for AI agents",
+    "homepage": "https://github.com/pixell-global/sayou"
+  },
+  "plugins": [
+    {
+      "name": "sayou",
+      "version": "0.2.1",
+      "source": "./plugin",
+      "description": "Persistent knowledge workspace — structured files, versioning, semantic search across sessions"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Thumbs.db
 
 # MCP config (contains API keys)
 .mcp.json
+!plugin/.mcp.json
 
 # SQLite databases
 *.db

--- a/README.md
+++ b/README.md
@@ -16,15 +16,23 @@ Databases were designed for transactions — they reduce nuance to fit a schema.
 
 ## Quick Start
 
+### Claude Code (recommended)
+
+```bash
+claude plugin install sayou@pixell-global
+```
+
+One command. This installs the plugin with lifecycle hooks (workspace context on session start, passive activity capture, session summaries) and skills (`/ws`, `/save`, `/recall`). If `sayou` isn't installed yet, the plugin auto-installs it on first run.
+
+### pip install
+
 ```bash
 pip install sayou && sayou init --claude
 ```
 
-That's it. Restart Claude Code and you're connected.
+This installs sayou and configures `~/.claude/mcp.json`. You get the 11 MCP tools but no hooks or skills. You can also use `--cursor` or `--windsurf`, or run `sayou init` without flags to get the config snippet to paste manually.
 
-`--claude` auto-configures `~/.claude/mcp.json`. You can also use `--cursor` or `--windsurf`, or run `sayou init` without flags to get the config snippet to paste manually.
-
-To verify, run `sayou status` — you should see your workspace path, database location, and `11 tools registered`. If you see errors, jump to [Troubleshooting](#troubleshooting).
+To verify either method, run `sayou status` — you should see your workspace path, database location, and `11 tools registered`. If you see errors, jump to [Troubleshooting](#troubleshooting).
 
 ## Try It
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "sayou",
+  "version": "0.2.1",
+  "description": "Persistent knowledge workspace for Claude Code — structured files, versioning, search, and knowledge graph across sessions",
+  "author": { "name": "Pixell" },
+  "repository": "https://github.com/pixell-global/sayou",
+  "license": "Apache-2.0",
+  "keywords": ["workspace", "knowledge", "memory", "persistence", "versioning", "mcp"]
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sayou": {
+      "type": "stdio",
+      "command": "sayou"
+    }
+  }
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,40 @@
+{
+  "description": "Sayou workspace hooks",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure-sayou.js\" && node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.js\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/auto-capture.js\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.js\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "sayou-plugin",
+  "version": "0.2.1",
+  "private": true,
+  "type": "module"
+}

--- a/plugin/scripts/auto-capture.js
+++ b/plugin/scripts/auto-capture.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+/**
+ * auto-capture.js — PostToolUse hook for passive activity capture.
+ *
+ * Receives tool use data via stdin (JSON with tool_name, tool_input,
+ * tool_output). Captures significant work into daily activity log files
+ * in the workspace at activity/YYYY-MM-DD.md.
+ *
+ * Capture strategy:
+ *   Write/Edit  → file path + purpose (change)
+ *   Bash        → git commits, test results, deployments (command)
+ *   Read        → config/architecture files only (discovery)
+ *   WebFetch    → URL + key findings (discovery)
+ *   WebSearch   → query + findings (discovery)
+ *   Task        → subagent results (discovery)
+ *   Glob/Grep   → skip (low-value exploration)
+ *   AskUser     → skip (UX interaction)
+ *
+ * Always exits 0. Never blocks tool execution.
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { openSync, readSync, closeSync } from "node:fs";
+
+// Tools to skip entirely
+const SKIP_TOOLS = new Set([
+  "Glob",
+  "Grep",
+  "AskUserQuestion",
+  "EnterPlanMode",
+  "ExitPlanMode",
+  "TaskCreate",
+  "TaskUpdate",
+  "TaskList",
+  "TaskGet",
+  "ListMcpResourcesTool",
+  "ReadMcpResourceTool",
+]);
+
+// Bash commands to skip (low-value)
+const SKIP_BASH_PATTERNS = [
+  /^\s*ls\b/,
+  /^\s*cat\b/,
+  /^\s*which\b/,
+  /^\s*echo\b/,
+  /^\s*cd\b/,
+  /^\s*pwd\b/,
+  /^\s*head\b/,
+  /^\s*tail\b/,
+  /^\s*wc\b/,
+  /^\s*sayou\b/,  // skip our own CLI calls to avoid recursion
+];
+
+// Read paths worth capturing (config, architecture, important docs)
+const INTERESTING_READ_PATTERNS = [
+  /\.env/i,
+  /config/i,
+  /architect/i,
+  /readme/i,
+  /claude\.md/i,
+  /package\.json$/i,
+  /pyproject\.toml$/i,
+  /docker/i,
+  /makefile/i,
+  /\.ya?ml$/i,
+];
+
+function readStdin() {
+  try {
+    const chunks = [];
+    const fd = openSync("/dev/stdin", "r");
+    const buf = Buffer.alloc(65536);
+    let bytesRead;
+    while ((bytesRead = readSync(fd, buf, 0, buf.length)) > 0) {
+      chunks.push(buf.slice(0, bytesRead));
+    }
+    closeSync(fd);
+    return Buffer.concat(chunks).toString("utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function classify(toolName, toolInput, toolOutput) {
+  if (SKIP_TOOLS.has(toolName)) return null;
+
+  switch (toolName) {
+    case "Write":
+    case "NotebookEdit": {
+      const path = toolInput?.file_path || toolInput?.notebook_path || "unknown";
+      const shortPath = path.replace(/^\/.*\//, "");
+      return { type: "change", summary: `\`${shortPath}\` — created/wrote file` };
+    }
+
+    case "Edit": {
+      const path = toolInput?.file_path || "unknown";
+      const shortPath = path.replace(/^\/.*\//, "");
+      return { type: "change", summary: `\`${shortPath}\` — edited file` };
+    }
+
+    case "Bash": {
+      const cmd = (toolInput?.command || "").trim();
+      if (!cmd) return null;
+
+      // Skip low-value commands
+      for (const pat of SKIP_BASH_PATTERNS) {
+        if (pat.test(cmd)) return null;
+      }
+
+      // Git commits are high-value
+      if (/git commit/.test(cmd)) {
+        const msgMatch = cmd.match(/-m\s+["']([^"']+)["']/);
+        const msg = msgMatch ? msgMatch[1] : "commit";
+        return { type: "command", summary: `git commit: "${msg}"` };
+      }
+
+      // Git push
+      if (/git push/.test(cmd)) {
+        return { type: "command", summary: `git push` };
+      }
+
+      // Test runs
+      if (/pytest|npm test|jest|vitest|cargo test/.test(cmd)) {
+        const passed = toolOutput && /passed|PASS/.test(toolOutput);
+        const failed = toolOutput && /failed|FAIL|ERROR/.test(toolOutput);
+        const status = failed ? "failed" : passed ? "passed" : "ran";
+        return { type: "command", summary: `tests ${status}` };
+      }
+
+      // Deployments
+      if (/deploy|docker build|npm run build/.test(cmd)) {
+        return { type: "command", summary: truncate(cmd, 80) };
+      }
+
+      // Install commands
+      if (/pip install|npm install|brew install/.test(cmd)) {
+        return { type: "command", summary: truncate(cmd, 80) };
+      }
+
+      // Generic meaningful bash (skip if too short/simple)
+      if (cmd.length > 10) {
+        return { type: "command", summary: truncate(cmd, 80) };
+      }
+
+      return null;
+    }
+
+    case "Read": {
+      const path = toolInput?.file_path || "";
+      const interesting = INTERESTING_READ_PATTERNS.some((p) => p.test(path));
+      if (!interesting) return null;
+      const shortPath = path.replace(/^\/.*\//, "");
+      return { type: "discovery", summary: `read \`${shortPath}\`` };
+    }
+
+    case "WebFetch": {
+      const url = toolInput?.url || "unknown URL";
+      const host = url.replace(/^https?:\/\//, "").split("/")[0];
+      return { type: "discovery", summary: `fetched ${host}` };
+    }
+
+    case "WebSearch": {
+      const query = toolInput?.query || "unknown query";
+      return { type: "discovery", summary: `searched "${truncate(query, 60)}"` };
+    }
+
+    case "Task": {
+      const desc = toolInput?.description || "subagent task";
+      return { type: "discovery", summary: truncate(desc, 80) };
+    }
+
+    default: {
+      // MCP workspace tools — skip to avoid recursion with our own workspace
+      if (toolName?.startsWith("mcp__sayou__")) return null;
+      // Unknown tool — capture if it has output
+      if (toolOutput && String(toolOutput).length > 50) {
+        return { type: "discovery", summary: `${toolName} tool used` };
+      }
+      return null;
+    }
+  }
+}
+
+function truncate(str, max) {
+  if (str.length <= max) return str;
+  return str.slice(0, max - 3) + "...";
+}
+
+function writeActivityEntry(entry) {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const time = now.toTimeString().slice(0, 5);
+  const path = `activity/${date}.md`;
+
+  const line = `- ${time} — [${entry.type}] ${entry.summary}`;
+
+  // Try to read existing file
+  let existing = null;
+  try {
+    existing = execSync(`sayou file read "${path}"`, {
+      stdio: "pipe",
+      timeout: 5000,
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    // File doesn't exist yet
+  }
+
+  const monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  const dateDisplay = `${monthNames[now.getMonth()]} ${now.getDate()}, ${now.getFullYear()}`;
+
+  let content;
+  if (existing && !existing.includes("not found") && !existing.includes("does not exist")) {
+    // Append to existing — update entry count in frontmatter
+    const lines = existing.split("\n");
+    // Count existing entries
+    const entryCount = lines.filter((l) => /^- \d{2}:\d{2}/.test(l)).length + 1;
+
+    // Update entries count in frontmatter
+    const updated = existing.replace(/entries: \d+/, `entries: ${entryCount}`);
+    content = updated + "\n" + line;
+  } else {
+    // Create new file
+    content = [
+      "---",
+      "type: activity-log",
+      `date: ${date}`,
+      "entries: 1",
+      "---",
+      `# Activity — ${dateDisplay}`,
+      "",
+      line,
+    ].join("\n");
+  }
+
+  try {
+    // Use spawnSync with stdin for content to handle special characters
+    spawnSync("sayou", ["file", "write", path, "-"], {
+      input: content,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5000,
+    });
+  } catch {
+    // Silent failure — never block tool execution
+  }
+}
+
+function main() {
+  try {
+    const raw = readStdin();
+    if (!raw) {
+      process.exit(0);
+    }
+
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      process.exit(0);
+    }
+
+    const toolName = data.tool_name || data.toolName || "";
+    const toolInput = data.tool_input || data.toolInput || data.input || {};
+    const toolOutput = data.tool_output || data.toolOutput || data.output || "";
+
+    const entry = classify(toolName, toolInput, String(toolOutput).slice(0, 500));
+
+    if (entry) {
+      writeActivityEntry(entry);
+    }
+  } catch {
+    // Never fail, never block
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/plugin/scripts/ensure-sayou.js
+++ b/plugin/scripts/ensure-sayou.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+ * ensure-sayou.js — Verify sayou CLI is available.
+ *
+ * Runs before session-start.js. If sayou is missing, outputs install
+ * instructions but always exits 0 (never blocks session start).
+ * Sets a flag file at ~/.sayou/.plugin-ok on success so subsequent
+ * hooks can skip re-checking.
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const FLAG_DIR = join(homedir(), ".sayou");
+const FLAG_FILE = join(FLAG_DIR, ".plugin-ok");
+
+function sayouAvailable() {
+  try {
+    execSync("sayou status", { stdio: "pipe", timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  // Fast path: already verified this install
+  if (existsSync(FLAG_FILE)) {
+    process.exit(0);
+  }
+
+  if (sayouAvailable()) {
+    // Mark as verified
+    if (!existsSync(FLAG_DIR)) {
+      mkdirSync(FLAG_DIR, { recursive: true });
+    }
+    writeFileSync(FLAG_FILE, new Date().toISOString());
+    process.exit(0);
+  }
+
+  // sayou not found — try auto-install
+  try {
+    execSync("pip install sayou", { stdio: "pipe", timeout: 60000 });
+  } catch {
+    // pip install failed — show manual instructions
+    const msg = [
+      "[sayou] not found on PATH",
+      "",
+      "Install:  pip install sayou",
+      "Then:     sayou init",
+      "",
+      "docs: github.com/pixell-global/sayou",
+    ].join("\n");
+    process.stdout.write(msg);
+    process.exit(0);
+  }
+
+  // Verify install succeeded
+  if (sayouAvailable()) {
+    // Run init to create default workspace
+    try {
+      execSync("sayou init", { stdio: "pipe", timeout: 10000 });
+    } catch {
+      // init failure is non-fatal
+    }
+
+    if (!existsSync(FLAG_DIR)) {
+      mkdirSync(FLAG_DIR, { recursive: true });
+    }
+    writeFileSync(FLAG_FILE, new Date().toISOString());
+  } else {
+    process.stdout.write("[sayou] install succeeded but CLI not on PATH. Restart your shell.\n");
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/plugin/scripts/session-end.js
+++ b/plugin/scripts/session-end.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+/**
+ * session-end.js — Stop hook.
+ *
+ * Writes a brief session summary to sessions/YYYY-MM-DD-{short_id}.md
+ * if the workspace was used during this session. Updates the
+ * plugin.last_active KV key for the SessionStart delta display.
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { stdio: "pipe", timeout: 10000, encoding: "utf-8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function writeFile(path, content) {
+  try {
+    spawnSync("sayou", ["file", "write", path, "-"], {
+      input: content,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10000,
+    });
+  } catch {
+    // Silent failure
+  }
+}
+
+function getTodayActivity() {
+  const today = new Date().toISOString().slice(0, 10);
+  const raw = run(`sayou file read "activity/${today}.md"`);
+  if (!raw || raw.includes("not found") || raw.includes("does not exist")) {
+    return null;
+  }
+  return raw;
+}
+
+function extractStats(activityContent) {
+  const lines = activityContent.split("\n").filter((l) => /^- \d{2}:\d{2}/.test(l));
+  if (lines.length === 0) return null;
+
+  const types = { change: 0, command: 0, discovery: 0 };
+  for (const line of lines) {
+    const match = line.match(/\[(\w+)\]/);
+    if (match && types[match[1]] !== undefined) {
+      types[match[1]]++;
+    }
+  }
+
+  return { total: lines.length, ...types };
+}
+
+function main() {
+  // Update last active
+  const now = new Date().toISOString();
+  run(`sayou kv set "plugin.last_active" '"${now}"'`);
+
+  // Check if there's activity from today
+  const activity = getTodayActivity();
+  if (!activity) {
+    // No workspace activity this session — skip summary
+    process.exit(0);
+  }
+
+  const stats = extractStats(activity);
+  if (!stats || stats.total === 0) {
+    process.exit(0);
+  }
+
+  // Generate session summary
+  const date = now.slice(0, 10);
+  const shortId = randomBytes(3).toString("hex");
+  const path = `sessions/${date}-${shortId}.md`;
+
+  const parts = [];
+  if (stats.change > 0) parts.push(`${stats.change} changes`);
+  if (stats.command > 0) parts.push(`${stats.command} commands`);
+  if (stats.discovery > 0) parts.push(`${stats.discovery} discoveries`);
+  const statLine = parts.join(", ");
+
+  // Extract the last few activity entries for context
+  const recentLines = activity
+    .split("\n")
+    .filter((l) => /^- \d{2}:\d{2}/.test(l))
+    .slice(-10)
+    .join("\n");
+
+  const content = [
+    "---",
+    "type: session-summary",
+    `date: ${date}`,
+    `entries: ${stats.total}`,
+    `changes: ${stats.change}`,
+    `commands: ${stats.command}`,
+    `discoveries: ${stats.discovery}`,
+    "---",
+    `# Session — ${date}`,
+    "",
+    statLine,
+    "",
+    "## Recent Activity",
+    "",
+    recentLines,
+    "",
+  ].join("\n");
+
+  writeFile(path, content);
+  process.exit(0);
+}
+
+main();

--- a/plugin/scripts/session-start.js
+++ b/plugin/scripts/session-start.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+ * session-start.js — SessionStart hook.
+ *
+ * Displays a workspace context summary at the start of each session.
+ * Shows a file tree with frontmatter metadata and version counts,
+ * plus a delta of changes since the last session.
+ *
+ * Output is capped at ~400 tokens to stay lightweight.
+ */
+
+import { execSync } from "node:child_process";
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { stdio: "pipe", timeout: 10000, encoding: "utf-8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function parseFileList(json) {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+function relativeTime(dateStr) {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  if (isNaN(then)) return "";
+  const diff = now - then;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w ago`;
+}
+
+function formatTree(files) {
+  const MAX_FILES = 20;
+  const lines = [];
+  const folders = new Map(); // folder -> [{name, meta, versions, updated}]
+
+  for (const f of files) {
+    const parts = f.path.split("/").filter(Boolean);
+    const name = parts.pop();
+    const folder = parts.length > 0 ? parts.join("/") + "/" : "";
+
+    if (!folders.has(folder)) {
+      folders.set(folder, []);
+    }
+    folders.get(folder).push({
+      name,
+      meta: f.frontmatter || {},
+      versions: f.versions || f.version || 1,
+      updated: f.updated_at || f.created_at || "",
+    });
+  }
+
+  let shown = 0;
+  const sortedFolders = [...folders.keys()].sort();
+
+  for (const folder of sortedFolders) {
+    if (shown >= MAX_FILES) break;
+
+    if (folder) {
+      lines.push(`  ${folder}`);
+    }
+
+    const entries = folders.get(folder);
+    for (const entry of entries) {
+      if (shown >= MAX_FILES) break;
+
+      const metaParts = [];
+
+      // Show key frontmatter fields inline
+      for (const key of ["status", "type", "topic", "priority"]) {
+        if (entry.meta[key]) {
+          metaParts.push(`${key}=${entry.meta[key]}`);
+        }
+      }
+
+      const metaStr = metaParts.length > 0 ? `  ${metaParts.join(", ")}` : "";
+      const versionStr = `v${entry.versions}`;
+      const timeStr = relativeTime(entry.updated);
+      const timeDisplay = timeStr ? `, ${timeStr}` : "";
+
+      const prefix = folder ? "    " : "  ";
+      lines.push(`${prefix}${entry.name}${metaStr}     [${versionStr}${timeDisplay}]`);
+      shown++;
+    }
+  }
+
+  const remaining = files.length - shown;
+  if (remaining > 0) {
+    lines.push(`  +${remaining} more files`);
+  }
+
+  return lines.join("\n");
+}
+
+function getActivitySummary() {
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+  let todayCount = 0;
+  let yesterdayCount = 0;
+
+  const todayLog = run(`sayou file read "activity/${today}.md" --json`);
+  if (todayLog) {
+    try {
+      const parsed = JSON.parse(todayLog);
+      const content = parsed.content || todayLog;
+      todayCount = (content.match(/^- \d/gm) || []).length;
+    } catch {
+      // count lines starting with "- " and a timestamp
+      todayCount = (todayLog.match(/^- \d/gm) || []).length;
+    }
+  }
+
+  const yesterdayLog = run(`sayou file read "activity/${yesterday}.md" --json`);
+  if (yesterdayLog) {
+    try {
+      const parsed = JSON.parse(yesterdayLog);
+      const content = parsed.content || yesterdayLog;
+      yesterdayCount = (content.match(/^- \d/gm) || []).length;
+    } catch {
+      yesterdayCount = (yesterdayLog.match(/^- \d/gm) || []).length;
+    }
+  }
+
+  if (todayCount === 0 && yesterdayCount === 0) return "";
+
+  const parts = [];
+  if (todayCount > 0) parts.push(`${todayCount} today`);
+  if (yesterdayCount > 0) parts.push(`${yesterdayCount} yesterday`);
+  return `recent activity: ${parts.join(", ")}`;
+}
+
+function getLastActive() {
+  const raw = run('sayou kv get "plugin.last_active"');
+  if (!raw) return null;
+  try {
+    // KV returns JSON-encoded string
+    const val = JSON.parse(raw);
+    if (typeof val === "string") return val;
+    if (val && val.value) return typeof val.value === "string" ? val.value : JSON.parse(val.value);
+  } catch {
+    return raw.replace(/"/g, "");
+  }
+  return null;
+}
+
+function main() {
+  // Get file listing
+  const rawList = run("sayou file list / --recursive --json");
+  const data = rawList ? parseFileList(rawList) : null;
+
+  // Determine files array from response
+  let files = [];
+  if (Array.isArray(data)) {
+    files = data;
+  } else if (data && Array.isArray(data.files)) {
+    files = data.files;
+  } else if (data && Array.isArray(data.items)) {
+    files = data.items;
+  }
+
+  // Filter out activity logs and session files from the tree display
+  const displayFiles = files.filter(
+    (f) => !f.path.startsWith("activity/") && !f.path.startsWith("sessions/")
+  );
+
+  const output = [];
+
+  if (displayFiles.length === 0) {
+    // Empty workspace
+    output.push("[sayou] workspace");
+    output.push("");
+    output.push("Your workspace is empty. Start building knowledge:");
+    output.push('  "save a note about [topic]" — creates a versioned file');
+    output.push("  /save — quick-save key decisions from this session");
+    output.push("  /recall — search past knowledge");
+    output.push("");
+    output.push("docs: github.com/pixell-global/sayou");
+  } else {
+    // Populated workspace
+    const lastActive = getLastActive();
+    const lastActiveStr = lastActive ? `, last active ${relativeTime(lastActive)}` : "";
+    const activityStr = getActivitySummary();
+
+    output.push(`[sayou] workspace (${files.length} files${lastActiveStr})`);
+    output.push("");
+    output.push(formatTree(displayFiles));
+
+    if (activityStr) {
+      output.push("");
+      output.push(`  ${activityStr}`);
+    }
+  }
+
+  // Update last active timestamp
+  try {
+    const now = new Date().toISOString();
+    run(`sayou kv set "plugin.last_active" '"${now}"'`);
+  } catch {
+    // non-fatal
+  }
+
+  process.stdout.write(output.join("\n") + "\n");
+}
+
+main();

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: recall
+description: Search past knowledge in the sayou workspace
+user_invocable: true
+triggers:
+  - "what did we decide about"
+  - "do we have research on"
+  - "find notes about"
+  - "what do we know about"
+  - "search workspace for"
+  - "recall"
+---
+
+# /recall — Search Past Knowledge
+
+Search the sayou workspace for past decisions, research, notes, and other saved knowledge.
+
+## Instructions
+
+Use a multi-step search strategy to find the most relevant results:
+
+### Step 1: Structured search (fastest)
+
+Use `workspace_search` with the user's query. This searches file paths and frontmatter text.
+
+```
+workspace_search(query="auth architecture", limit=10)
+```
+
+If the user mentions a specific type or status, add filters:
+
+```
+workspace_search(filters={"type": "decision"}, query="database")
+workspace_search(filters={"status": "approved"})
+```
+
+### Step 2: Content search (if Step 1 is insufficient)
+
+Use `workspace_grep` to search inside file contents:
+
+```
+workspace_grep(query="PostgreSQL", context_lines=3)
+```
+
+### Step 3: Semantic search (if Steps 1-2 miss)
+
+Use `workspace_semantic_search` for meaning-based retrieval when exact keywords don't match:
+
+```
+workspace_semantic_search(query="why we chose that database", top_k=5)
+```
+
+Note: This only works if the workspace has embeddings enabled (`SAYOU_EMBEDDING_PROVIDER` set).
+
+### Step 4: Read and present
+
+For each relevant file found, use `workspace_read` to get the full content. Present the key information clearly, citing which file it came from and when it was last updated.
+
+## Output Format
+
+Present results with clear attribution:
+
+```
+Found in decisions/database-selection.md (v2, updated 3d ago):
+
+  Decision: PostgreSQL over MySQL
+  Status: approved
+  Reasoning: Better JSON support, superior FTS, row-level security
+```
+
+If multiple files match, show a summary list first, then offer to read specific ones in detail.
+
+## Tips
+
+- Start with the broadest reasonable search, then narrow down
+- If nothing is found, tell the user — don't make up information
+- Mention the file path so the user can reference or update it later
+- If the workspace is empty, suggest using `/save` to start building knowledge
+- For time-based queries ("what did we do last week"), use `workspace_search` with date filters or check `activity/` logs

--- a/plugin/skills/save/SKILL.md
+++ b/plugin/skills/save/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: save
+description: Quick-save key findings, decisions, or notes to the sayou workspace
+user_invocable: true
+triggers:
+  - "save this"
+  - "remember this"
+  - "save findings"
+  - "save decision"
+  - "save note"
+  - "save what we learned"
+---
+
+# /save — Quick Save to Workspace
+
+Save key knowledge from the current conversation to the sayou workspace as a structured, versioned file.
+
+## Instructions
+
+1. **Analyze the conversation** — identify the most important knowledge to save:
+   - Decisions made (and their reasoning)
+   - Research findings
+   - Bug fixes and root causes
+   - Architecture choices
+   - Meeting notes or action items
+
+2. **Choose a logical path** based on content type:
+   - `decisions/` — architectural decisions, technology choices, design rationale
+   - `research/` — competitive analysis, market research, technical investigation
+   - `notes/` — meeting notes, brainstorms, general notes
+   - `bugs/` — bug investigations, root causes, fixes applied
+   - `guides/` — how-to guides, setup instructions, runbooks
+
+3. **Write with YAML frontmatter** — always include structured metadata:
+
+   ```yaml
+   ---
+   type: decision | research | note | bug-report | guide
+   status: draft | reviewed | approved | archived
+   topic: short-topic-name
+   date: YYYY-MM-DD
+   tags: [relevant, tags]
+   ---
+   ```
+
+4. **Use `workspace_write`** to save the file. Use a descriptive filename in kebab-case (e.g., `auth-token-refresh-fix.md`).
+
+5. **Confirm what was saved** — show the path, key frontmatter fields, and mention it's versioned (they can update it later and the old version is preserved).
+
+## Example
+
+If the conversation discussed choosing PostgreSQL over MySQL:
+
+```markdown
+---
+type: decision
+status: approved
+topic: database-selection
+date: 2026-02-19
+tags: [database, infrastructure]
+---
+# Database Selection: PostgreSQL
+
+## Decision
+PostgreSQL over MySQL for the new service.
+
+## Reasoning
+- Better JSON support (JSONB) for our flexible schema needs
+- Superior full-text search (eliminates need for Elasticsearch)
+- Row-level security for multi-tenant isolation
+
+## Alternatives Considered
+- MySQL: Familiar to team but weaker JSON/FTS support
+- MongoDB: Overkill for our relational data patterns
+```
+
+Save to: `decisions/database-selection.md`
+
+## Tips
+
+- If the user says "/save" without context, scan the conversation for the most significant knowledge and propose what to save
+- If multiple things are worth saving, save them as separate files
+- Always use `workspace_write` (not regular Write tool) — this goes to the persistent workspace, not the local filesystem
+- If a file at the chosen path already exists, `workspace_write` creates a new version (nothing is overwritten)

--- a/plugin/skills/ws/SKILL.md
+++ b/plugin/skills/ws/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ws
+description: Browse and manage sayou workspace — list files, search, view history
+user_invocable: true
+triggers:
+  - "what's in my workspace"
+  - "show workspace"
+  - "list files"
+  - "workspace status"
+  - "browse workspace"
+---
+
+# /ws — Workspace Browser
+
+Browse the sayou workspace. Show the user what's stored, find specific files, or check recent changes.
+
+## Instructions
+
+1. **Start with an overview** — use `workspace_list` with `path: "/"` and `recursive: true` to show the full file tree. Present it as a clean, readable tree with frontmatter metadata.
+
+2. **If the user asks about a specific file**, use `workspace_read` to show its contents. Mention the version number and when it was last updated.
+
+3. **If the user asks about changes**, use `workspace_history` on the relevant file to show version history. Offer to diff specific versions.
+
+4. **If the workspace is empty**, tell the user:
+   - Use `/save` to save findings or decisions from this session
+   - Ask Claude to "save a note about [topic]" to create a file
+   - Files support YAML frontmatter for metadata (status, type, tags, etc.)
+
+5. **For large workspaces**, use `workspace_search` or `workspace_grep` to find specific files rather than listing everything.
+
+## Output Format
+
+Show files as a tree with key metadata:
+
+```
+research/
+  competitor-analysis.md    status=draft     [v3, 2d ago]
+  market-sizing.md          status=reviewed  [v1, 5d ago]
+decisions/
+  auth-architecture.md      status=approved  [v2, 1w ago]
+notes/
+  standup-2026-02-19.md     type=meeting     [v1, today]
+```
+
+Keep it concise. Don't read every file's contents unless asked — the tree overview is usually enough.


### PR DESCRIPTION
## Summary

- Adds a complete Claude Code plugin (`plugin/`) with lifecycle hooks and skills
- SessionStart hook displays workspace file tree with metadata, versions, and activity counts
- PostToolUse hook passively captures significant work (Write/Edit/Bash/WebSearch) into daily `activity/YYYY-MM-DD.md` logs
- Stop hook writes session summaries to `sessions/` folder
- Three skills: `/ws` (browse workspace), `/save` (quick-save knowledge), `/recall` (search past knowledge)
- `ensure-sayou.js` auto-installs `sayou` via pip if missing
- Zero npm dependencies — all scripts use Node.js builtins only
- Updated README with `claude plugin install sayou@pixell-global` as recommended install method

## Install

```
claude plugin install sayou@pixell-global
```

## Test plan

- [ ] `claude plugin install sayou@pixell-global` succeeds after merge to main
- [ ] New session shows workspace context (file tree or empty state)
- [ ] `/ws`, `/save`, `/recall` appear in tab completion
- [ ] Activity logs created after Write/Edit/Bash tool uses
- [ ] Session summary written on session end
- [ ] Works alongside claude-mem without conflicts
- [ ] `node --check` passes on all 4 scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)