### PR TITLE
Add cloud mode with API key support (v0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "sayou",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "source": ".",
       "description": "Persistent knowledge workspace — structured files, versioning, semantic search across sessions"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sayou",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Persistent knowledge workspace for Claude Code — structured files, versioning, search, and knowledge graph across sessions",
   "author": { "name": "Pixell" },
   "repository": "https://github.com/pixell-global/sayou",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "sayou": {
       "type": "stdio",
-      "command": "sayou"
+      "command": "sh",
+      "args": [
+        "-c",
+        "KEY=\"${SAYOU_API_KEY:-}\"; [ -z \"$KEY\" ] && [ -f \"$HOME/.sayou/api-key\" ] && read -r KEY < \"$HOME/.sayou/api-key\"; if [ -n \"$KEY\" ]; then exec npx -y mcp-remote https://drive.sayou.dev/api/v1/mcp --header \"Authorization: Bearer $KEY\"; elif command -v sayou >/dev/null 2>&1; then exec sayou; else echo 'sayou: no API key or CLI found' >&2; exit 1; fi"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayou-plugin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module"
 }

--- a/scripts/auto-capture.js
+++ b/scripts/auto-capture.js
@@ -7,21 +7,19 @@
  * tool_output). Captures significant work into daily activity log files
  * in the workspace at activity/YYYY-MM-DD.md.
  *
- * Capture strategy:
- *   Write/Edit  → file path + purpose (change)
- *   Bash        → git commits, test results, deployments (command)
- *   Read        → config/architecture files only (discovery)
- *   WebFetch    → URL + key findings (discovery)
- *   WebSearch   → query + findings (discovery)
- *   Task        → subagent results (discovery)
- *   Glob/Grep   → skip (low-value exploration)
- *   AskUser     → skip (UX interaction)
+ * Supports cloud mode (MCP endpoint via fetch) and local mode (CLI).
  *
  * Always exits 0. Never blocks tool execution.
  */
 
-import { execSync, spawnSync } from "node:child_process";
 import { openSync, readSync, closeSync } from "node:fs";
+import {
+  isCloudMode,
+  workspaceRead,
+  workspaceWrite,
+  cliRun,
+  cliWrite,
+} from "./helpers.js";
 
 // Tools to skip entirely
 const SKIP_TOOLS = new Set([
@@ -49,7 +47,7 @@ const SKIP_BASH_PATTERNS = [
   /^\s*head\b/,
   /^\s*tail\b/,
   /^\s*wc\b/,
-  /^\s*sayou\b/,  // skip our own CLI calls to avoid recursion
+  /^\s*sayou\b/, // skip our own CLI calls to avoid recursion
 ];
 
 // Read paths worth capturing (config, architecture, important docs)
@@ -88,7 +86,8 @@ function classify(toolName, toolInput, toolOutput) {
   switch (toolName) {
     case "Write":
     case "NotebookEdit": {
-      const path = toolInput?.file_path || toolInput?.notebook_path || "unknown";
+      const path =
+        toolInput?.file_path || toolInput?.notebook_path || "unknown";
       const shortPath = path.replace(/^\/.*\//, "");
       return { type: "change", summary: `\`${shortPath}\` — created/wrote file` };
     }
@@ -103,24 +102,20 @@ function classify(toolName, toolInput, toolOutput) {
       const cmd = (toolInput?.command || "").trim();
       if (!cmd) return null;
 
-      // Skip low-value commands
       for (const pat of SKIP_BASH_PATTERNS) {
         if (pat.test(cmd)) return null;
       }
 
-      // Git commits are high-value
       if (/git commit/.test(cmd)) {
         const msgMatch = cmd.match(/-m\s+["']([^"']+)["']/);
         const msg = msgMatch ? msgMatch[1] : "commit";
         return { type: "command", summary: `git commit: "${msg}"` };
       }
 
-      // Git push
       if (/git push/.test(cmd)) {
         return { type: "command", summary: `git push` };
       }
 
-      // Test runs
       if (/pytest|npm test|jest|vitest|cargo test/.test(cmd)) {
         const passed = toolOutput && /passed|PASS/.test(toolOutput);
         const failed = toolOutput && /failed|FAIL|ERROR/.test(toolOutput);
@@ -128,17 +123,14 @@ function classify(toolName, toolInput, toolOutput) {
         return { type: "command", summary: `tests ${status}` };
       }
 
-      // Deployments
       if (/deploy|docker build|npm run build/.test(cmd)) {
         return { type: "command", summary: truncate(cmd, 80) };
       }
 
-      // Install commands
       if (/pip install|npm install|brew install/.test(cmd)) {
         return { type: "command", summary: truncate(cmd, 80) };
       }
 
-      // Generic meaningful bash (skip if too short/simple)
       if (cmd.length > 10) {
         return { type: "command", summary: truncate(cmd, 80) };
       }
@@ -162,7 +154,10 @@ function classify(toolName, toolInput, toolOutput) {
 
     case "WebSearch": {
       const query = toolInput?.query || "unknown query";
-      return { type: "discovery", summary: `searched "${truncate(query, 60)}"` };
+      return {
+        type: "discovery",
+        summary: `searched "${truncate(query, 60)}"`,
+      };
     }
 
     case "Task": {
@@ -171,9 +166,8 @@ function classify(toolName, toolInput, toolOutput) {
     }
 
     default: {
-      // MCP workspace tools — skip to avoid recursion with our own workspace
+      // MCP workspace tools — skip to avoid recursion
       if (toolName?.startsWith("mcp__sayou__")) return null;
-      // Unknown tool — capture if it has output
       if (toolOutput && String(toolOutput).length > 50) {
         return { type: "discovery", summary: `${toolName} tool used` };
       }
@@ -187,66 +181,77 @@ function truncate(str, max) {
   return str.slice(0, max - 3) + "...";
 }
 
-function writeActivityEntry(entry) {
+function buildActivityContent(existing, line, now) {
+  const date = now.toISOString().slice(0, 10);
+  const monthNames = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  const dateDisplay = `${monthNames[now.getMonth()]} ${now.getDate()}, ${now.getFullYear()}`;
+
+  if (
+    existing &&
+    !existing.includes("not found") &&
+    !existing.includes("does not exist") &&
+    !existing.includes("File not found") &&
+    !existing.includes("No matches")
+  ) {
+    const lines = existing.split("\n");
+    const entryCount =
+      lines.filter((l) => /^- \d{2}:\d{2}/.test(l)).length + 1;
+    const updated = existing.replace(/entries: \d+/, `entries: ${entryCount}`);
+    return updated + "\n" + line;
+  }
+
+  return [
+    "---",
+    "type: activity-log",
+    `date: ${date}`,
+    "entries: 1",
+    "---",
+    `# Activity — ${dateDisplay}`,
+    "",
+    line,
+  ].join("\n");
+}
+
+// ── Cloud mode ──────────────────────────────────────────────
+
+async function cloudWriteActivity(entry) {
   const now = new Date();
   const date = now.toISOString().slice(0, 10);
   const time = now.toTimeString().slice(0, 5);
   const path = `activity/${date}.md`;
-
   const line = `- ${time} — [${entry.type}] ${entry.summary}`;
 
-  // Try to read existing file
   let existing = null;
   try {
-    existing = execSync(`sayou file read "${path}"`, {
-      stdio: "pipe",
-      timeout: 5000,
-      encoding: "utf-8",
-    }).trim();
+    existing = await workspaceRead(path);
   } catch {
-    // File doesn't exist yet
+    // file doesn't exist yet
   }
 
-  const monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-  const dateDisplay = `${monthNames[now.getMonth()]} ${now.getDate()}, ${now.getFullYear()}`;
-
-  let content;
-  if (existing && !existing.includes("not found") && !existing.includes("does not exist")) {
-    // Append to existing — update entry count in frontmatter
-    const lines = existing.split("\n");
-    // Count existing entries
-    const entryCount = lines.filter((l) => /^- \d{2}:\d{2}/.test(l)).length + 1;
-
-    // Update entries count in frontmatter
-    const updated = existing.replace(/entries: \d+/, `entries: ${entryCount}`);
-    content = updated + "\n" + line;
-  } else {
-    // Create new file
-    content = [
-      "---",
-      "type: activity-log",
-      `date: ${date}`,
-      "entries: 1",
-      "---",
-      `# Activity — ${dateDisplay}`,
-      "",
-      line,
-    ].join("\n");
-  }
-
-  try {
-    // Use spawnSync with stdin for content to handle special characters
-    spawnSync("sayou", ["file", "write", path, "-"], {
-      input: content,
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 5000,
-    });
-  } catch {
-    // Silent failure — never block tool execution
-  }
+  const content = buildActivityContent(existing, line, now);
+  await workspaceWrite(path, content);
 }
 
-function main() {
+// ── Local mode ──────────────────────────────────────────────
+
+function localWriteActivity(entry) {
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const time = now.toTimeString().slice(0, 5);
+  const path = `activity/${date}.md`;
+  const line = `- ${time} — [${entry.type}] ${entry.summary}`;
+
+  const existing = cliRun(`sayou file read "${path}"`);
+  const content = buildActivityContent(existing, line, now);
+  cliWrite(path, content);
+}
+
+// ── Entry point ─────────────────────────────────────────────
+
+async function main() {
   try {
     const raw = readStdin();
     if (!raw) {
@@ -267,7 +272,11 @@ function main() {
     const entry = classify(toolName, toolInput, String(toolOutput).slice(0, 500));
 
     if (entry) {
-      writeActivityEntry(entry);
+      if (isCloudMode()) {
+        await cloudWriteActivity(entry);
+      } else {
+        localWriteActivity(entry);
+      }
     }
   } catch {
     // Never fail, never block

--- a/scripts/ensure-sayou.js
+++ b/scripts/ensure-sayou.js
@@ -1,30 +1,24 @@
 #!/usr/bin/env node
 
 /**
- * ensure-sayou.js — Verify sayou CLI is available.
+ * ensure-sayou.js — Verify sayou connectivity (cloud or local).
  *
- * Runs before session-start.js. If sayou is missing, outputs install
- * instructions but always exits 0 (never blocks session start).
+ * Runs before session-start.js. Cloud-first: checks for API key,
+ * then falls back to local CLI. If neither is available, outputs
+ * setup instructions but always exits 0 (never blocks session start).
+ *
  * Sets a flag file at ~/.sayou/.plugin-ok on success so subsequent
  * hooks can skip re-checking.
  */
 
-import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
-
-const FLAG_DIR = join(homedir(), ".sayou");
-const FLAG_FILE = join(FLAG_DIR, ".plugin-ok");
-
-function sayouAvailable() {
-  try {
-    execSync("sayou status", { stdio: "pipe", timeout: 10000 });
-    return true;
-  } catch {
-    return false;
-  }
-}
+import { existsSync, writeFileSync } from "node:fs";
+import {
+  getApiKey,
+  isCLIAvailable,
+  ensureDir,
+  SAYOU_DIR,
+  FLAG_FILE,
+} from "./helpers.js";
 
 function main() {
   // Fast path: already verified this install
@@ -32,49 +26,35 @@ function main() {
     process.exit(0);
   }
 
-  if (sayouAvailable()) {
-    // Mark as verified
-    if (!existsSync(FLAG_DIR)) {
-      mkdirSync(FLAG_DIR, { recursive: true });
-    }
-    writeFileSync(FLAG_FILE, new Date().toISOString());
+  // Cloud mode: API key found
+  if (getApiKey()) {
+    ensureDir(SAYOU_DIR);
+    writeFileSync(FLAG_FILE, `cloud:${new Date().toISOString()}`);
     process.exit(0);
   }
 
-  // sayou not found — try auto-install
-  try {
-    execSync("pip install sayou", { stdio: "pipe", timeout: 60000 });
-  } catch {
-    // pip install failed — show manual instructions
-    const msg = [
-      "[sayou] not found on PATH",
-      "",
-      "Install:  pip install sayou",
-      "Then:     sayou init",
-      "",
-      "docs: github.com/pixell-global/sayou",
-    ].join("\n");
-    process.stdout.write(msg);
+  // Local mode: CLI available
+  if (isCLIAvailable()) {
+    ensureDir(SAYOU_DIR);
+    writeFileSync(FLAG_FILE, `local:${new Date().toISOString()}`);
     process.exit(0);
   }
 
-  // Verify install succeeded
-  if (sayouAvailable()) {
-    // Run init to create default workspace
-    try {
-      execSync("sayou init", { stdio: "pipe", timeout: 10000 });
-    } catch {
-      // init failure is non-fatal
-    }
-
-    if (!existsSync(FLAG_DIR)) {
-      mkdirSync(FLAG_DIR, { recursive: true });
-    }
-    writeFileSync(FLAG_FILE, new Date().toISOString());
-  } else {
-    process.stdout.write("[sayou] install succeeded but CLI not on PATH. Restart your shell.\n");
-  }
-
+  // Neither found — show setup instructions
+  const msg = [
+    "[sayou] Connect your workspace:",
+    "",
+    "  Cloud (recommended):",
+    "    1. Create an API key at https://drive.sayou.dev/settings",
+    '    2. echo "YOUR_KEY" > ~/.sayou/api-key',
+    "    3. Restart Claude Code",
+    "",
+    "  Local:",
+    "    pip install sayou && sayou init",
+    "",
+    "  docs: github.com/pixell-global/sayou",
+  ].join("\n");
+  process.stdout.write(msg + "\n");
   process.exit(0);
 }
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,0 +1,178 @@
+/**
+ * helpers.js — Shared module for sayou plugin hooks.
+ *
+ * Provides cloud (HTTP fetch to MCP endpoint) and local (CLI execSync)
+ * modes with unified workspace and KV operations.
+ *
+ * Cloud mode: API key from ~/.sayou/api-key or $SAYOU_API_KEY
+ * Local mode: sayou CLI on PATH
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export const SAYOU_DIR = join(homedir(), ".sayou");
+export const API_KEY_FILE = join(SAYOU_DIR, "api-key");
+export const FLAG_FILE = join(SAYOU_DIR, ".plugin-ok");
+const MCP_ENDPOINT = "https://drive.sayou.dev/api/v1/mcp";
+
+// ── Mode detection ──────────────────────────────────────────
+
+export function getApiKey() {
+  if (process.env.SAYOU_API_KEY) {
+    return process.env.SAYOU_API_KEY.trim();
+  }
+  try {
+    if (existsSync(API_KEY_FILE)) {
+      return readFileSync(API_KEY_FILE, "utf-8").trim();
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export function isCloudMode() {
+  return !!getApiKey();
+}
+
+export function isCLIAvailable() {
+  try {
+    execSync("sayou status", { stdio: "pipe", timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Cloud: MCP JSON-RPC over HTTP ───────────────────────────
+
+let _mcpId = 0;
+
+export async function mcpCall(toolName, args = {}) {
+  const key = getApiKey();
+  if (!key) throw new Error("No API key");
+
+  const resp = await fetch(MCP_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+      id: ++_mcpId,
+    }),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`MCP ${resp.status}`);
+  }
+
+  const json = await resp.json();
+  if (json.error) {
+    throw new Error(json.error.message || "MCP error");
+  }
+
+  // Extract text from MCP tool result content array
+  const content = json.result?.content;
+  if (Array.isArray(content)) {
+    const text = content.find((c) => c.type === "text");
+    if (text) return text.text;
+  }
+  return json.result;
+}
+
+// ── Local: CLI helpers ──────────────────────────────────────
+
+export function cliRun(cmd) {
+  try {
+    return execSync(cmd, {
+      stdio: "pipe",
+      timeout: 10000,
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export function cliWrite(path, content) {
+  try {
+    spawnSync("sayou", ["file", "write", path, "-"], {
+      input: content,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10000,
+    });
+  } catch {
+    // silent
+  }
+}
+
+// ── Unified workspace operations ────────────────────────────
+
+export async function workspaceList(path = "/", recursive = true) {
+  if (isCloudMode()) {
+    return await mcpCall("workspace_list", { path, recursive });
+  }
+  const flags = recursive ? "--recursive --json" : "--json";
+  return cliRun(`sayou file list "${path}" ${flags}`);
+}
+
+export async function workspaceRead(path) {
+  if (isCloudMode()) {
+    return await mcpCall("workspace_read", { path });
+  }
+  return cliRun(`sayou file read "${path}"`);
+}
+
+export async function workspaceReadJson(path) {
+  if (isCloudMode()) {
+    return await mcpCall("workspace_read", { path });
+  }
+  return cliRun(`sayou file read "${path}" --json`);
+}
+
+export async function workspaceWrite(path, content) {
+  if (isCloudMode()) {
+    return await mcpCall("workspace_write", { path, content });
+  }
+  cliWrite(path, content);
+}
+
+export async function kvGet(key) {
+  if (isCloudMode()) {
+    try {
+      const result = await mcpCall("workspace_kv", { action: "get", key });
+      if (typeof result === "string") {
+        if (result.startsWith("Key not found")) return null;
+        // Format: "**key** = value"
+        const match = result.match(/\*\*.*?\*\*\s*=\s*(.*)/s);
+        if (match) return match[1].trim();
+      }
+      return result;
+    } catch {
+      return null;
+    }
+  }
+  return cliRun(`sayou kv get "${key}"`);
+}
+
+export async function kvSet(key, value) {
+  const val = typeof value === "string" ? value : JSON.stringify(value);
+  if (isCloudMode()) {
+    await mcpCall("workspace_kv", { action: "set", key, value: val });
+  } else {
+    cliRun(`sayou kv set "${key}" '${val}'`);
+  }
+}
+
+// ── Utilities ───────────────────────────────────────────────
+
+export function ensureDir(dir) {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}

--- a/scripts/session-end.js
+++ b/scripts/session-end.js
@@ -6,42 +6,24 @@
  * Writes a brief session summary to sessions/YYYY-MM-DD-{short_id}.md
  * if the workspace was used during this session. Updates the
  * plugin.last_active KV key for the SessionStart delta display.
+ *
+ * Supports cloud mode (MCP endpoint via fetch) and local mode (CLI).
  */
 
-import { execSync, spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-
-function run(cmd) {
-  try {
-    return execSync(cmd, { stdio: "pipe", timeout: 10000, encoding: "utf-8" }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function writeFile(path, content) {
-  try {
-    spawnSync("sayou", ["file", "write", path, "-"], {
-      input: content,
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 10000,
-    });
-  } catch {
-    // Silent failure
-  }
-}
-
-function getTodayActivity() {
-  const today = new Date().toISOString().slice(0, 10);
-  const raw = run(`sayou file read "activity/${today}.md"`);
-  if (!raw || raw.includes("not found") || raw.includes("does not exist")) {
-    return null;
-  }
-  return raw;
-}
+import {
+  isCloudMode,
+  workspaceRead,
+  workspaceWrite,
+  kvSet,
+  cliRun,
+  cliWrite,
+} from "./helpers.js";
 
 function extractStats(activityContent) {
-  const lines = activityContent.split("\n").filter((l) => /^- \d{2}:\d{2}/.test(l));
+  const lines = activityContent
+    .split("\n")
+    .filter((l) => /^- \d{2}:\d{2}/.test(l));
   if (lines.length === 0) return null;
 
   const types = { change: 0, command: 0, discovery: 0 };
@@ -55,27 +37,8 @@ function extractStats(activityContent) {
   return { total: lines.length, ...types };
 }
 
-function main() {
-  // Update last active
-  const now = new Date().toISOString();
-  run(`sayou kv set "plugin.last_active" '"${now}"'`);
-
-  // Check if there's activity from today
-  const activity = getTodayActivity();
-  if (!activity) {
-    // No workspace activity this session — skip summary
-    process.exit(0);
-  }
-
-  const stats = extractStats(activity);
-  if (!stats || stats.total === 0) {
-    process.exit(0);
-  }
-
-  // Generate session summary
-  const date = now.slice(0, 10);
-  const shortId = randomBytes(3).toString("hex");
-  const path = `sessions/${date}-${shortId}.md`;
+function buildSessionContent(stats, activity, now) {
+  const date = now.toISOString().slice(0, 10);
 
   const parts = [];
   if (stats.change > 0) parts.push(`${stats.change} changes`);
@@ -83,14 +46,13 @@ function main() {
   if (stats.discovery > 0) parts.push(`${stats.discovery} discoveries`);
   const statLine = parts.join(", ");
 
-  // Extract the last few activity entries for context
   const recentLines = activity
     .split("\n")
     .filter((l) => /^- \d{2}:\d{2}/.test(l))
     .slice(-10)
     .join("\n");
 
-  const content = [
+  return [
     "---",
     "type: session-summary",
     `date: ${date}`,
@@ -108,8 +70,95 @@ function main() {
     recentLines,
     "",
   ].join("\n");
+}
 
-  writeFile(path, content);
+// ── Cloud mode ──────────────────────────────────────────────
+
+async function cloudMain() {
+  const now = new Date();
+
+  // Update last active
+  try {
+    await kvSet("plugin.last_active", `"${now.toISOString()}"`);
+  } catch {}
+
+  // Check for today's activity
+  const today = now.toISOString().slice(0, 10);
+  let activity = null;
+  try {
+    activity = await workspaceRead(`activity/${today}.md`);
+  } catch {}
+
+  if (
+    !activity ||
+    (typeof activity === "string" &&
+      (activity.includes("not found") ||
+        activity.includes("does not exist") ||
+        activity.includes("File not found")))
+  ) {
+    process.exit(0);
+  }
+
+  const stats = extractStats(activity);
+  if (!stats || stats.total === 0) {
+    process.exit(0);
+  }
+
+  const shortId = randomBytes(3).toString("hex");
+  const path = `sessions/${today}-${shortId}.md`;
+  const content = buildSessionContent(stats, activity, now);
+
+  try {
+    await workspaceWrite(path, content);
+  } catch {}
+
+  process.exit(0);
+}
+
+// ── Local mode ──────────────────────────────────────────────
+
+function localMain() {
+  const now = new Date();
+
+  // Update last active
+  cliRun(`sayou kv set "plugin.last_active" '"${now.toISOString()}"'`);
+
+  // Check for today's activity
+  const today = now.toISOString().slice(0, 10);
+  const activity = cliRun(`sayou file read "activity/${today}.md"`);
+  if (
+    !activity ||
+    activity.includes("not found") ||
+    activity.includes("does not exist")
+  ) {
+    process.exit(0);
+  }
+
+  const stats = extractStats(activity);
+  if (!stats || stats.total === 0) {
+    process.exit(0);
+  }
+
+  const shortId = randomBytes(3).toString("hex");
+  const path = `sessions/${today}-${shortId}.md`;
+  const content = buildSessionContent(stats, activity, now);
+
+  cliWrite(path, content);
+  process.exit(0);
+}
+
+// ── Entry point ─────────────────────────────────────────────
+
+async function main() {
+  try {
+    if (isCloudMode()) {
+      await cloudMain();
+    } else {
+      localMain();
+    }
+  } catch {
+    // Never fail, never block
+  }
   process.exit(0);
 }
 

--- a/scripts/session-start.js
+++ b/scripts/session-start.js
@@ -4,29 +4,19 @@
  * session-start.js — SessionStart hook.
  *
  * Displays a workspace context summary at the start of each session.
- * Shows a file tree with frontmatter metadata and version counts,
- * plus a delta of changes since the last session.
+ * Supports cloud mode (MCP endpoint via fetch) and local mode (CLI).
  *
  * Output is capped at ~400 tokens to stay lightweight.
  */
 
-import { execSync } from "node:child_process";
-
-function run(cmd) {
-  try {
-    return execSync(cmd, { stdio: "pipe", timeout: 10000, encoding: "utf-8" }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function parseFileList(json) {
-  try {
-    return JSON.parse(json);
-  } catch {
-    return null;
-  }
-}
+import {
+  isCloudMode,
+  workspaceList,
+  workspaceRead,
+  kvGet,
+  kvSet,
+  cliRun,
+} from "./helpers.js";
 
 function relativeTime(dateStr) {
   const now = Date.now();
@@ -47,7 +37,7 @@ function relativeTime(dateStr) {
 function formatTree(files) {
   const MAX_FILES = 20;
   const lines = [];
-  const folders = new Map(); // folder -> [{name, meta, versions, updated}]
+  const folders = new Map();
 
   for (const f of files) {
     const parts = f.path.split("/").filter(Boolean);
@@ -80,8 +70,6 @@ function formatTree(files) {
       if (shown >= MAX_FILES) break;
 
       const metaParts = [];
-
-      // Show key frontmatter fields inline
       for (const key of ["status", "type", "topic", "priority"]) {
         if (entry.meta[key]) {
           metaParts.push(`${key}=${entry.meta[key]}`);
@@ -94,7 +82,9 @@ function formatTree(files) {
       const timeDisplay = timeStr ? `, ${timeStr}` : "";
 
       const prefix = folder ? "    " : "  ";
-      lines.push(`${prefix}${entry.name}${metaStr}     [${versionStr}${timeDisplay}]`);
+      lines.push(
+        `${prefix}${entry.name}${metaStr}     [${versionStr}${timeDisplay}]`
+      );
       shown++;
     }
   }
@@ -107,64 +97,93 @@ function formatTree(files) {
   return lines.join("\n");
 }
 
-function getActivitySummary() {
-  const today = new Date().toISOString().slice(0, 10);
-  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
-
-  let todayCount = 0;
-  let yesterdayCount = 0;
-
-  const todayLog = run(`sayou file read "activity/${today}.md" --json`);
-  if (todayLog) {
-    try {
-      const parsed = JSON.parse(todayLog);
-      const content = parsed.content || todayLog;
-      todayCount = (content.match(/^- \d/gm) || []).length;
-    } catch {
-      // count lines starting with "- " and a timestamp
-      todayCount = (todayLog.match(/^- \d/gm) || []).length;
-    }
-  }
-
-  const yesterdayLog = run(`sayou file read "activity/${yesterday}.md" --json`);
-  if (yesterdayLog) {
-    try {
-      const parsed = JSON.parse(yesterdayLog);
-      const content = parsed.content || yesterdayLog;
-      yesterdayCount = (content.match(/^- \d/gm) || []).length;
-    } catch {
-      yesterdayCount = (yesterdayLog.match(/^- \d/gm) || []).length;
-    }
-  }
-
-  if (todayCount === 0 && yesterdayCount === 0) return "";
-
-  const parts = [];
-  if (todayCount > 0) parts.push(`${todayCount} today`);
-  if (yesterdayCount > 0) parts.push(`${yesterdayCount} yesterday`);
-  return `recent activity: ${parts.join(", ")}`;
+function countActivityEntries(content) {
+  if (!content) return 0;
+  return (content.match(/^- \d{2}:\d{2}/gm) || []).length;
 }
 
-function getLastActive() {
-  const raw = run('sayou kv get "plugin.last_active"');
-  if (!raw) return null;
+function parseFileList(json) {
   try {
-    // KV returns JSON-encoded string
-    const val = JSON.parse(raw);
-    if (typeof val === "string") return val;
-    if (val && val.value) return typeof val.value === "string" ? val.value : JSON.parse(val.value);
+    return JSON.parse(json);
   } catch {
-    return raw.replace(/"/g, "");
+    return null;
   }
-  return null;
 }
 
-function main() {
-  // Get file listing
-  const rawList = run("sayou file list / --recursive --json");
+// ── Cloud mode ──────────────────────────────────────────────
+
+async function cloudMain() {
+  const output = [];
+
+  try {
+    const listing = await workspaceList("/", true);
+
+    if (!listing || (typeof listing === "string" && listing.includes("(0 files)"))) {
+      output.push("[sayou] workspace (cloud)");
+      output.push("");
+      output.push("Your workspace is empty. Start building knowledge:");
+      output.push('  "save a note about [topic]" — creates a versioned file');
+      output.push("  /save — quick-save key decisions from this session");
+      output.push("  /recall — search past knowledge");
+    } else {
+      // Get last active time
+      let lastActiveStr = "";
+      try {
+        const lastActive = await kvGet("plugin.last_active");
+        if (lastActive) {
+          // Parse JSON-encoded string or raw value
+          let val = lastActive;
+          try { val = JSON.parse(lastActive); } catch {}
+          if (typeof val === "string") {
+            lastActiveStr = `, last active ${relativeTime(val)}`;
+          }
+        }
+      } catch {}
+
+      output.push(`[sayou] workspace (cloud${lastActiveStr})`);
+      output.push("");
+      output.push(typeof listing === "string" ? listing : JSON.stringify(listing));
+
+      // Activity summary
+      const today = new Date().toISOString().slice(0, 10);
+      const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+      const parts = [];
+
+      try {
+        const todayLog = await workspaceRead(`activity/${today}.md`);
+        const todayCount = countActivityEntries(todayLog);
+        if (todayCount > 0) parts.push(`${todayCount} today`);
+      } catch {}
+
+      try {
+        const yesterdayLog = await workspaceRead(`activity/${yesterday}.md`);
+        const yesterdayCount = countActivityEntries(yesterdayLog);
+        if (yesterdayCount > 0) parts.push(`${yesterdayCount} yesterday`);
+      } catch {}
+
+      if (parts.length > 0) {
+        output.push("");
+        output.push(`  recent activity: ${parts.join(", ")}`);
+      }
+    }
+  } catch (e) {
+    output.push(`[sayou] workspace (cloud — error: ${e.message})`);
+  }
+
+  // Update last active
+  try {
+    await kvSet("plugin.last_active", `"${new Date().toISOString()}"`);
+  } catch {}
+
+  process.stdout.write(output.join("\n") + "\n");
+}
+
+// ── Local mode ──────────────────────────────────────────────
+
+function localMain() {
+  const rawList = cliRun("sayou file list / --recursive --json");
   const data = rawList ? parseFileList(rawList) : null;
 
-  // Determine files array from response
   let files = [];
   if (Array.isArray(data)) {
     files = data;
@@ -174,7 +193,6 @@ function main() {
     files = data.items;
   }
 
-  // Filter out activity logs and session files from the tree display
   const displayFiles = files.filter(
     (f) => !f.path.startsWith("activity/") && !f.path.startsWith("sessions/")
   );
@@ -182,7 +200,6 @@ function main() {
   const output = [];
 
   if (displayFiles.length === 0) {
-    // Empty workspace
     output.push("[sayou] workspace");
     output.push("");
     output.push("Your workspace is empty. Start building knowledge:");
@@ -192,30 +209,77 @@ function main() {
     output.push("");
     output.push("docs: github.com/pixell-global/sayou");
   } else {
-    // Populated workspace
-    const lastActive = getLastActive();
-    const lastActiveStr = lastActive ? `, last active ${relativeTime(lastActive)}` : "";
-    const activityStr = getActivitySummary();
+    let lastActiveStr = "";
+    const lastActiveRaw = cliRun('sayou kv get "plugin.last_active"');
+    if (lastActiveRaw) {
+      try {
+        let val = JSON.parse(lastActiveRaw);
+        if (typeof val === "object" && val.value) val = typeof val.value === "string" ? val.value : JSON.parse(val.value);
+        if (typeof val === "string") lastActiveStr = `, last active ${relativeTime(val)}`;
+      } catch {
+        const cleaned = lastActiveRaw.replace(/"/g, "");
+        if (cleaned) lastActiveStr = `, last active ${relativeTime(cleaned)}`;
+      }
+    }
 
     output.push(`[sayou] workspace (${files.length} files${lastActiveStr})`);
     output.push("");
     output.push(formatTree(displayFiles));
 
-    if (activityStr) {
+    // Activity summary
+    const today = new Date().toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const parts = [];
+
+    const todayLog = cliRun(`sayou file read "activity/${today}.md" --json`);
+    if (todayLog) {
+      try {
+        const parsed = JSON.parse(todayLog);
+        const content = parsed.content || todayLog;
+        const count = countActivityEntries(content);
+        if (count > 0) parts.push(`${count} today`);
+      } catch {
+        const count = countActivityEntries(todayLog);
+        if (count > 0) parts.push(`${count} today`);
+      }
+    }
+
+    const yesterdayLog = cliRun(`sayou file read "activity/${yesterday}.md" --json`);
+    if (yesterdayLog) {
+      try {
+        const parsed = JSON.parse(yesterdayLog);
+        const content = parsed.content || yesterdayLog;
+        const count = countActivityEntries(content);
+        if (count > 0) parts.push(`${count} yesterday`);
+      } catch {
+        const count = countActivityEntries(yesterdayLog);
+        if (count > 0) parts.push(`${count} yesterday`);
+      }
+    }
+
+    if (parts.length > 0) {
       output.push("");
-      output.push(`  ${activityStr}`);
+      output.push(`  recent activity: ${parts.join(", ")}`);
     }
   }
 
-  // Update last active timestamp
+  // Update last active
   try {
     const now = new Date().toISOString();
-    run(`sayou kv set "plugin.last_active" '"${now}"'`);
-  } catch {
-    // non-fatal
-  }
+    cliRun(`sayou kv set "plugin.last_active" '"${now}"'`);
+  } catch {}
 
   process.stdout.write(output.join("\n") + "\n");
+}
+
+// ── Entry point ─────────────────────────────────────────────
+
+async function main() {
+  if (isCloudMode()) {
+    await cloudMain();
+  } else {
+    localMain();
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

- Plugin is now **cloud-first**: detects API key → connects to hosted MCP endpoint at `drive.sayou.dev`. Falls back to local CLI if no key.
- New `scripts/helpers.js` shared module provides unified cloud/local abstractions for all hooks
- `.mcp.json` uses smart shell launcher: reads API key from `~/.sayou/api-key` or `$SAYOU_API_KEY`, launches `mcp-remote` for cloud, or `sayou` CLI for local
- All hooks (session-start, auto-capture, session-end) converted to async with cloud mode support via `fetch()` to MCP JSON-RPC endpoint
- `ensure-sayou.js` rewritten for cloud-first setup flow with instructions pointing to `drive.sayou.dev/settings`
- Version bump 0.2.1 → 0.3.0

## Test plan

- [ ] Remove `~/.sayou/api-key` and `~/.sayou/.plugin-ok` → verify setup prompt appears
- [ ] Create `~/.sayou/api-key` with valid key → restart → verify MCP tools connect to cloud
- [ ] Test `workspace_write` → verify file appears in Sayou Drive web UI
- [ ] Test `/save` skill → verify file saved to cloud
- [ ] Test session-start hook → verify workspace listing shows
- [ ] Test auto-capture → verify activity log written to cloud
- [ ] Verify local mode still works when no API key but CLI installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)