### PR TITLE
Add MCP directory listing configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,5 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 ## License
 
 Apache 2.0 — See [LICENSE](./LICENSE)
+
+<!-- mcp-name: io.github.pixell-global/sayou -->

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["syumpx"]
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.pixell-global/sayou",
+  "title": "sayou",
+  "description": "A file-system inspired context store for AI agents. Versioned files with YAML frontmatter, full-text search, and knowledge graph.",
+  "repository": {
+    "url": "https://github.com/pixell-global/sayou",
+    "source": "github"
+  },
+  "version": "0.2.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "sayou",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,31 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      databaseUrl:
+        type: string
+        description: "Database URL (SQLite or MySQL). Defaults to ~/.sayou/sayou.db"
+      workspace:
+        type: string
+        default: "default"
+        description: "Workspace slug"
+      orgId:
+        type: string
+        description: "Organization ID for multi-tenant setups"
+      userId:
+        type: string
+        description: "User ID for access control"
+  commandFunction: |-
+    (config) => ({
+      command: 'uvx',
+      args: ['sayou'],
+      env: Object.assign({},
+        config.databaseUrl ? { SAYOU_DATABASE_URL: config.databaseUrl } : {},
+        config.workspace ? { SAYOU_WORKSPACE: config.workspace } : {},
+        config.orgId ? { SAYOU_ORG_ID: config.orgId } : {},
+        config.userId ? { SAYOU_USER_ID: config.userId } : {}
+      )
+    })


### PR DESCRIPTION
## Summary
- **smithery.yaml**: Config for [Smithery](https://smithery.ai) marketplace listing (uvx-based stdio install)
- **glama.json**: Ownership claim file for [Glama](https://glama.ai) MCP directory
- **server.json**: Metadata for the [Official MCP Registry](https://registry.modelcontextprotocol.io/)
- **README.md**: Added `mcp-name` verification tag (hidden HTML comment) required by MCP Registry for PyPI package validation

## Context
Submitting sayou to multiple MCP directories for developer discoverability. These config files are required by each platform to list/claim the server.

## After merge
1. Re-publish to PyPI (so README with `mcp-name` tag is live)
2. Run `mcp-publisher publish` to register with Official MCP Registry
3. Submit to Smithery at https://smithery.ai/new
4. Claim ownership on Glama after auto-indexing