### PR TITLE
docs: add /plugin install method to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Databases were designed for transactions — they reduce nuance to fit a schema.
 
 ### Claude Code (recommended)
 
+From within Claude Code:
+
+```
+/plugin install sayou@pixell-global
+```
+
+Or from the terminal:
+
 ```bash
 claude plugin install sayou@pixell-global
 ```


### PR DESCRIPTION
## Summary
- Show both installation methods in the Quick Start section: `/plugin install sayou@pixell-global` (from within Claude Code) and `claude plugin install sayou@pixell-global` (from the terminal)

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)