### PR TITLE
Add sayou auth CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ claude plugin install sayou@pixell-global
 
 One command. This installs the plugin with lifecycle hooks (workspace context on session start, passive activity capture, session summaries) and skills (`/ws`, `/save`, `/recall`). If `sayou` isn't installed yet, the plugin auto-installs it on first run.
 
+> **Cloud mode**: To sync your workspace via [Sayou Drive](https://drive.sayou.dev), run `sayou auth` after installing and paste your API key from [Settings](https://drive.sayou.dev/settings).
+
 ### pip install
 
 ```bash
@@ -181,6 +183,11 @@ sayou file search --query "hello" --filter status=active
 # KV store
 sayou kv set config.theme '"dark"'
 sayou kv get config.theme
+
+# Cloud authentication
+sayou auth            # Connect to Sayou Drive (interactive)
+sayou auth status     # Show current mode (cloud/local)
+sayou auth logout     # Disconnect from Sayou Drive
 
 # Diagnostics
 sayou init      # Initialize local setup

--- a/sayou/__main__.py
+++ b/sayou/__main__.py
@@ -146,6 +146,13 @@ def main():
     # ── status ───────────────────────────────────────────────────
     subparsers.add_parser("status", help="Show sayou diagnostic status")
 
+    # ── auth ──────────────────────────────────────────────────────
+    auth_parser = subparsers.add_parser("auth", help="Manage Sayou Drive API key")
+    auth_sub = auth_parser.add_subparsers(dest="auth_command")
+    auth_sub.add_parser("login", help="Save API key (interactive)")
+    auth_sub.add_parser("logout", help="Remove saved API key")
+    auth_sub.add_parser("status", help="Show current auth status")
+
     # ── audit ────────────────────────────────────────────────────
     audit_parser = subparsers.add_parser("audit", help="Query audit log")
     audit_parser.add_argument("--path", default=None, help="Filter by file path")
@@ -187,6 +194,17 @@ def main():
     if args.command == "status":
         from sayou.cli.status import run_status
         asyncio.run(run_status())
+        return
+
+    if args.command == "auth":
+        from sayou.cli.auth import run_auth_login, run_auth_logout, run_auth_status
+        sub = getattr(args, "auth_command", None)
+        if sub == "logout":
+            asyncio.run(run_auth_logout())
+        elif sub == "status":
+            asyncio.run(run_auth_status())
+        else:  # bare "sayou auth" or "sayou auth login"
+            asyncio.run(run_auth_login())
         return
 
     # CLI commands

--- a/sayou/cli/auth.py
+++ b/sayou/cli/auth.py
@@ -1,0 +1,172 @@
+"""sayou auth — manage Sayou Drive API key."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+SAYOU_DIR = Path.home() / ".sayou"
+API_KEY_FILE = SAYOU_DIR / "api-key"
+FLAG_FILE = SAYOU_DIR / ".plugin-ok"
+MCP_ENDPOINT = "https://drive.sayou.dev/api/v1/mcp"
+KEY_PREFIX = "sk-sayou-"
+
+
+def _get_saved_key() -> str | None:
+    """Read saved API key from file or env."""
+    env_key = os.environ.get("SAYOU_API_KEY")
+    if env_key:
+        return env_key.strip()
+    if API_KEY_FILE.exists():
+        return API_KEY_FILE.read_text().strip()
+    return None
+
+
+def _redact_key(key: str) -> str:
+    """Redact API key for display: sk-sayou-abc...wxyz."""
+    if len(key) <= 16:
+        return key[:4] + "..." + key[-4:]
+    return key[:12] + "..." + key[-4:]
+
+
+def _validate_key(key: str) -> tuple[bool, str]:
+    """Validate API key against Sayou Drive MCP endpoint.
+
+    Returns (success, message).
+    """
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "params": {},
+        "id": 1,
+    }).encode()
+
+    req = urllib.request.Request(
+        MCP_ENDPOINT,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {key}",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status == 200:
+                return True, "Valid"
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            return False, "Invalid API key (401 Unauthorized)"
+        return False, f"Server error ({e.code})"
+    except urllib.error.URLError as e:
+        return False, f"Connection failed: {e.reason}"
+    except Exception as e:
+        return False, f"Unexpected error: {e}"
+
+    return False, "Unexpected response"
+
+
+def _save_key(key: str) -> None:
+    """Save API key to ~/.sayou/api-key with 600 permissions."""
+    SAYOU_DIR.mkdir(parents=True, exist_ok=True)
+    API_KEY_FILE.write_text(key + "\n")
+    API_KEY_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 600
+
+
+def _clear_flag() -> None:
+    """Delete .plugin-ok so ensure-sayou.js re-detects mode."""
+    if FLAG_FILE.exists():
+        FLAG_FILE.unlink()
+
+
+async def run_auth_login() -> None:
+    """Interactive: prompt for key, validate, save."""
+    existing = _get_saved_key()
+    if existing:
+        redacted = _redact_key(existing)
+        source = "env" if os.environ.get("SAYOU_API_KEY") else "file"
+        print(f"  Existing key: {redacted} (from {source})")
+        print()
+        try:
+            answer = input("  Replace it? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if answer not in ("y", "yes"):
+            print("  Keeping existing key.")
+            return
+        print()
+
+    print("  Get your API key from: https://drive.sayou.dev/settings")
+    print()
+    try:
+        key = input("  Paste API key: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+
+    if not key:
+        print("  No key entered.")
+        return
+
+    # Format check
+    if not key.startswith(KEY_PREFIX):
+        print(f"  Error: Key must start with '{KEY_PREFIX}'")
+        sys.exit(1)
+
+    # Remote validation
+    print("  Validating...", end="", flush=True)
+    valid, message = _validate_key(key)
+    if not valid:
+        print(f" failed")
+        print(f"  Error: {message}")
+        sys.exit(1)
+
+    print(f" ok")
+
+    # Save
+    _save_key(key)
+    _clear_flag()
+
+    print()
+    print(f"  Saved to {API_KEY_FILE}")
+    print("  Mode: cloud (Sayou Drive)")
+    print()
+    print("  Restart Claude Code to connect.")
+
+
+async def run_auth_logout() -> None:
+    """Remove saved API key."""
+    if os.environ.get("SAYOU_API_KEY"):
+        print("  Note: $SAYOU_API_KEY env var is set — unset it to fully disconnect.")
+        print()
+
+    if API_KEY_FILE.exists():
+        API_KEY_FILE.unlink()
+        _clear_flag()
+        print("  Removed API key.")
+        print("  Mode: local")
+    else:
+        print("  No saved API key found.")
+
+    print()
+    print("  Restart Claude Code to apply.")
+
+
+async def run_auth_status() -> None:
+    """Show current auth status."""
+    key = _get_saved_key()
+    if key:
+        redacted = _redact_key(key)
+        source = "env" if os.environ.get("SAYOU_API_KEY") else "file"
+        print(f"  Mode:   cloud (Sayou Drive)")
+        print(f"  Key:    {redacted} ({source})")
+        print(f"  Server: {MCP_ENDPOINT}")
+    else:
+        print(f"  Mode:   local")
+        print(f"  To connect: sayou auth")

--- a/scripts/ensure-sayou.js
+++ b/scripts/ensure-sayou.js
@@ -46,7 +46,7 @@ function main() {
     "",
     "  Cloud (recommended):",
     "    1. Create an API key at https://drive.sayou.dev/settings",
-    '    2. echo "YOUR_KEY" > ~/.sayou/api-key',
+    "    2. Run: sayou auth",
     "    3. Restart Claude Code",
     "",
     "  Local:",


### PR DESCRIPTION
## Summary
- Adds `sayou auth` CLI command with `login`, `logout`, and `status` subcommands for managing Sayou Drive API keys
- Validates keys against the MCP endpoint before saving, checks `sk-sayou-` prefix, saves with `chmod 600`
- Updates `ensure-sayou.js` setup instructions and README with cloud mode docs

## Test plan
- [x] `sayou auth` prompts for key, validates against drive.sayou.dev, saves to `~/.sayou/api-key`
- [x] `sayou auth status` shows mode (cloud/local) with redacted key
- [x] `sayou auth logout` removes key, shows local mode
- [x] All 253 existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)