### PR TITLE
fix: block MCP workspace_write to synced source folders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sayou"
-version = "0.2.3"
+version = "0.2.4"
 description = "A file-system inspired context store for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sayou/server/__init__.py
+++ b/sayou/server/__init__.py
@@ -122,6 +122,18 @@ def create_server() -> tuple[FastMCP, WorkspaceService]:
             import base64 as b64
             org_id, user_id, workspace_slug = _identity()
 
+            # NEVER allow MCP to write to synced source folders.
+            # Synced content (Slack, Google Drive, Notion) is managed by the
+            # connector sync pipeline, NOT via MCP workspace_write.
+            _synced_prefixes = ("/slack/", "/gdrive/", "/gdrive-org/", "/notion/")
+            normalized = path if path.startswith("/") else f"/{path}"
+            if any(normalized.startswith(p) for p in _synced_prefixes):
+                return (
+                    f"Cannot write to synced folder '{normalized.split('/')[1]}/'. "
+                    "This content is managed by the connector sync pipeline. "
+                    "Edit in the source app instead."
+                )
+
             # If content_type indicates binary, decode from base64
             write_content: str | bytes = content
             if content_type and not content_type.startswith("text/") and content_type not in (


### PR DESCRIPTION
## Summary
- Prevents MCP workspace_write from writing to synced folders (/slack/, /gdrive/, /gdrive-org/, /notion/)
- Root cause: agent chat reads files via MCP (gets formatted "**Frontmatter:**" display text), then writes it back, overwriting real 253KB sync content with 333 bytes of formatted text
- The REST API already had this protection; this adds it to the MCP handler too
- Bumps to v0.2.4

## Evidence
Mutation log showed `agent_id=None` writes at 13:33:04 overwriting `agent_id='slack'` content from 13:30:36.

## Test plan
- [ ] Verify sayou-agent chat cannot write to /slack/ files
- [ ] Verify sync still writes correctly (uses Workspace.write with source='slack', not MCP)
- [ ] Run pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)